### PR TITLE
Add 'ABAP' (uppercase) alias

### DIFF
--- a/lib/rouge/lexers/abap.rb
+++ b/lib/rouge/lexers/abap.rb
@@ -9,6 +9,7 @@ module Rouge
       title "ABAP"
       desc "SAP - Advanced Business Application Programming"
       tag 'abap'
+      aliases 'ABAP'
       filenames '*.abap'
       mimetypes 'text/x-abap'
 


### PR DESCRIPTION
it's an acronym for "Advanced Business Application Programming" and therefore 'ABAP' should be valid